### PR TITLE
# feat: enhance PR creation workflow with Copilot and editor integration

### DIFF
--- a/confs/.config/gh/config.yml
+++ b/confs/.config/gh/config.yml
@@ -15,13 +15,13 @@ aliases:
     co: pr checkout
     id: issue develop -c $1
     ic: issue create
-    pc: pr create
     gcs: copilot suggest
     cps: copilot suggest
     disc: |
         api graphql --field query='query {
         }'
     wd: workflow view Deploy
+    pc: pr create -e
 # The path to a unix socket through which send HTTP connections. If blank, HTTP traffic will be handled by net/http.DefaultTransport.
 http_unix_socket:
 # What web browser gh should use when opening URLs. If blank, will refer to environment.

--- a/confs/.config/nvim/lua/plugins/copilot.lua
+++ b/confs/.config/nvim/lua/plugins/copilot.lua
@@ -34,10 +34,20 @@ local M = {
       { "nvim-lua/plenary.nvim" },
     },
     build = "make tiktoken", -- Only on MacOS or Linux
-    opts = {},
+    opts = {
+      model = "claude-3.7-sonnet-thought",
+      prompts = {
+        GithubPR = {
+          prompt =
+          "Create a PR description for the differences between main and HEAD. The first line should be a title, using a conventional commit style, such as 'feat: add new feature'. The rest of the PR description should be a detailed explanation of the changes. Focus on the logical changes, and not so much on how files have been moved around, or variables changed names",
+          context = "git:main..HEAD"
+        }
+      }
+    },
     keys = {
-      { '<leader>cc', "<cmd>CopilotChatToggle<CR>", desc = "Toggle Copilot Chat",   mode = { "v", "n" } },
-      { '<leader>cr', "<cmd>CopilotChatReview<CR>", desc = "Toggle Copilot Review", mode = "v" },
+      { '<leader>cc',  "<cmd>CopilotChatToggle<CR>",   desc = "Toggle Copilot Chat",     mode = { "v", "n" } },
+      { '<leader>cr',  "<cmd>CopilotChatReview<CR>",   desc = "Toggle Copilot Review",   mode = "v" },
+      { '<leader>cpr', "<cmd>CopilotChatGithubPR<CR>", desc = "Create a PR description", mode = "n" },
     }
   },
 }

--- a/confs/.zshrc
+++ b/confs/.zshrc
@@ -43,9 +43,10 @@ complete -C aws_completer aws
 alias vim=nvim
 alias k='kubectl'
 
-GH_PREFIX="IS_GH_CLI=1 gh"
-alias gh="$GH_PREFIX"
-
+GH_PREFIX="IS_GH_CLI=1"
+GH_PR_PREFIX="IS_GH_PR=1"
+alias gh="$GH_PREFIX gh"
+alias ghpc="$GH_PREFIX $GH_PR_PREFIX gh pr create -e"
 
 # Functions
 # =================================


### PR DESCRIPTION

This PR introduces several improvements to streamline the pull request creation workflow:

## Copilot Integration

- Configure copilot-chat.nvim to use claude-3.7-sonnet-thought model
- Add a custom "GithubPR" prompt for automatically generating PR descriptions
- Create a new keybinding (`<leader>cpr`) to trigger the PR description generation

## GitHub CLI Enhancements

- Update the `pc` alias in GitHub CLI config to use the `-e` flag, which opens PRs in an editor for review before submission
- Refactor shell aliases in .zshrc to better separate concerns:
  - Create distinct environment variables for GitHub CLI prefixes
  - Add a new `ghpc` alias that ensures PRs open in an editor

These changes collectively improve the developer experience when creating pull requests by leveraging AI assistance for PR descriptions and providing a more interactive editing workflow before submission.
